### PR TITLE
fix:お気に入り曲がユーザーごとに一意に定まるようにした

### DIFF
--- a/flask/src/README.md
+++ b/flask/src/README.md
@@ -14,7 +14,11 @@
   - [参考文献](https://self-development.info/mysql-connector-python%E3%81%A7mysql%E3%83%BBmariadb%E3%81%AB%E6%8E%A5%E7%B6%9A%E3%81%99%E3%82%8B/)
 
 # migration の仕方
-- srcディレクトリの中で以下のコマンドを実行
+- ~~srcディレクトリの中で以下のコマンドを実行~~
+- flaskコンテナの中で実行
+~~~
+$ docker container exec [flaskコンテナ名] [コンテナ内で実行するコマンド]
+~~~
 - 初期化
 ~~~python
 $ flask db init

--- a/flask/src/common/FavoriteMusicController.py
+++ b/flask/src/common/FavoriteMusicController.py
@@ -1,5 +1,6 @@
 # coding:utf-8
 from common.libs.FavoriteMusicData import FavoriteMusicData
+from common.libs.FavoriteMusicService import FavoriteMusicService
 
 class FavoriteMusicController:
     """お気に入り楽曲を管理するコントローラ
@@ -31,6 +32,8 @@ class FavoriteMusicController:
         Returns:
             dict: { error_message:(str), result:(0or1) }
         """
+        if(FavoriteMusicService.CheckExist(self.__request_data['user_id'],self.__request_data['music_id'])):
+            return {"error_message": "The music is already registered.", "result":0}
         try:
             # 登録するお気に入り曲オブジェクトを作成
             register_favorite_music = self.__FavoriteMusic(**self.__request_data)
@@ -39,6 +42,7 @@ class FavoriteMusicController:
             self.__db.session.add(register_favorite_music)
             self.__db.session.commit()
         except Exception as e:
+            print(str(e))
             return {"error_message": str(e), "result":0}
         
         return {"error_message":"", "result":1}
@@ -58,6 +62,7 @@ class FavoriteMusicController:
             for m in find_favorite_musics:
                 find_favorite_musics_re.append(vars(FavoriteMusicData(m)))
         except Exception as e:
+            print(str(e))
             return {"error_message": str(e),"result":0}
 
         re = {"error_message":"","result":1}
@@ -77,6 +82,7 @@ class FavoriteMusicController:
                 self.__db.session.delete(delete_favorite_music)
             self.__db.session.commit()
         except Exception as e:
+            print(str(e))
             return {"error_message": str(e),"result":0}
 
         return {"error_message":"","result":1}

--- a/flask/src/common/libs/FavoriteMusicService.py
+++ b/flask/src/common/libs/FavoriteMusicService.py
@@ -1,0 +1,11 @@
+from common.models.FavoriteMusic import FavoriteMusic
+
+class FavoriteMusicService:
+    def __init__(self) -> None:
+        pass
+
+    def CheckExist(user_id:str,music_id:str):
+        result = FavoriteMusic.query.filter_by(user_id = user_id,music_id = music_id).first()
+        if not result:
+            return False
+        return True

--- a/flask/src/common/libs/FavoriteMusicService.py
+++ b/flask/src/common/libs/FavoriteMusicService.py
@@ -5,6 +5,15 @@ class FavoriteMusicService:
         pass
 
     def CheckExist(user_id:str,music_id:str):
+        """ユーザーのお気に入り曲の重複確認
+
+        Args:
+            user_id (str): ユーザーID
+            music_id (str): 楽曲のID
+
+        Returns:
+            bool: 存在していたらTrue、存在していなかったらFalse
+        """
         result = FavoriteMusic.query.filter_by(user_id = user_id,music_id = music_id).first()
         if not result:
             return False

--- a/flask/src/common/models/FavoriteMusic.py
+++ b/flask/src/common/models/FavoriteMusic.py
@@ -12,8 +12,7 @@ class FavoriteMusic(db.Model):
                 autoincrement=True)
         music_id = db.Column(
                 db.String(255), 
-                nullable=False,
-                unique=True)
+                nullable=False)
         music_name = db.Column(
                 db.String(255), 
                 nullable=False)

--- a/flask/src/common/models/FavoriteMusic.py
+++ b/flask/src/common/models/FavoriteMusic.py
@@ -3,7 +3,9 @@ from common.libs.Database import db
 from sqlalchemy.dialects.mysql import MEDIUMINT as Mediumint
 
 class FavoriteMusic(db.Model): 
-        __table_args__=({"mysql_charset": "utf8mb4"})
+        __table_args__=(
+                db.UniqueConstraint('music_id', 'user_id', name='unique_user_music'),
+        )
         __tablename__ = 'favorite_musics'
 
         id = db.Column(

--- a/flask/src/config.py
+++ b/flask/src/config.py
@@ -7,11 +7,12 @@ class Config:
     DEBUG = True
 
     # SQLAlchemy
-    SQLALCHEMY_DATABASE_URI = 'mysql+pymysql://{user}:{password}@{host}/musicexplorer?charset=utf8'.format(**{
+    SQLALCHEMY_DATABASE_URI = 'mysql+pymysql://{user}:{password}@{host}:{port}/{db}?charset=utf8mb4'.format(**{
         'user': os.getenv('DB_USER_NAME', 'root'),
         'password': os.getenv('DB_USER_PASS', ''),
-        # 'host': 'localhost',
         'host': os.getenv('DB_HOST_NAME', 'localhost'),
+        'port':os.getenv('DB_PORT', 3306),
+        'db':os.getenv('DB_NAME','')
     })
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_ECHO = False


### PR DESCRIPTION
- テーブル定義を変更して、music_id の重複を許可
  - ユーザー同士で同じ曲をお気に入り登録してもエラーがでないようにした 
- FavoriteMusicService の CheckExist() 関数で登録しようとしているお気に入り曲が既に存在しているかの確認をする
  - ユーザーが同じ曲を複数登録しないようにした
 - migration しなおしてほしい
   - migrationのやり方を変更しました、READMEを参照してください 