### PR TITLE
audio_featureへのリクエスト楽曲数の上限値に関する不具合を修正

### DIFF
--- a/flask/src/common/MusicController.py
+++ b/flask/src/common/MusicController.py
@@ -195,8 +195,9 @@ class MusicController:
         max = 100
         i = 0
         while i < len(a_track_list)//100*100:
+            pre_i = i
             i += max
-            track_features.extend(self.spotify.audio_features(a_track_list[:i]))
+            track_features.extend(self.spotify.audio_features(a_track_list[pre_i:i]))
         track_features.extend(self.spotify.audio_features(a_track_list[i:]))
 
         for track_feature in track_features:

--- a/flask/src/common/MusicController.py
+++ b/flask/src/common/MusicController.py
@@ -183,14 +183,22 @@ class MusicController:
             
                
         
-        a_track_set = set(a_trackId_list)
+        a_track_list = list(set(a_trackId_list))
 
         
         
 
         track_list = []
+        
         # トラックIDから各種パラメータを取得
-        track_features = self.spotify.audio_features(list(a_track_set))
+        track_features = []
+        max = 100
+        i = 0
+        while i < len(a_track_list)//100*100:
+            i += max
+            track_features.extend(self.spotify.audio_features(a_track_list[:i]))
+        track_features.extend(self.spotify.audio_features(a_track_list[i:]))
+
         for track_feature in track_features:
 
             if not track_feature:


### PR DESCRIPTION
- 楽曲数が多いと、特徴データを取得するときにAPIの上限(100曲)を超えてしまい、エラーが出ていた
- 100曲ずつリクエストを送るようにした
- Bzとかもちゃんと表示されるようになっていると思う