### PR TITLE
Fix/#72 processed by url query

### DIFF
--- a/nuxt/src/components/Header.vue
+++ b/nuxt/src/components/Header.vue
@@ -8,7 +8,7 @@
         <p>{{ user_name }}</p>
         <p v-if="$store.getters.isAuthenticated" @click="signOut">ログアウト</p>
         <p v-else @click="openLoginModal">ログイン</p>
-        <input v-if="$route.path === '/'" type="text" v-model="artist_name" placeholder="artist name" @keypress.enter="onSubmit">
+        <input v-if="$route.path === '/' && Object.keys($route.query).length != 0" type="text" v-model="artist_name" placeholder="artist name" @keypress.enter="onSubmit">
     </div>
     
 </div>
@@ -84,9 +84,6 @@
                 })
             },
             toTop(){
-                if(this.$route.path == '/'){
-                    location.reload();
-                }
                 this.$router.push('/');
             },
             toManageFavorite(){

--- a/nuxt/src/components/MusicList.vue
+++ b/nuxt/src/components/MusicList.vue
@@ -35,13 +35,13 @@
         </div>
         <!-- /.nav -->
         <div class="recommend_artist_wrapper" v-if="recommend_artists.length > 0 && $store.state.recommend.show_recommend">
-            <nuxt-link to="/" class="recommend_artist_item" v-for="artist in recommend_artists" :key="artist.id" @click.native="searchMusics(artist.name)">
+            <a href="#" class="recommend_artist_item" v-for="artist in recommend_artists" :key="artist.id" @click.prevent="searchMusics(artist.name)">
                 <div class="artist_content_wrap">
                     <img :src="artist.image.url" alt="">
                     <div>{{ artist.name }}</div>
                 </div>
                 <!-- /.artist_content_wrap -->
-            </nuxt-link>
+            </a>
             <!-- /.recommend_artist_item -->
         </div>
     </div>

--- a/nuxt/src/components/Top.vue
+++ b/nuxt/src/components/Top.vue
@@ -8,13 +8,13 @@
         </div>
 
         <div class="recommend_artist_wrapper" v-if="recommend_artists.length > 0">
-            <nuxt-link to="/" class="recommend_artist_item" v-for="artist in recommend_artists" :key="artist.id" @click.native="searchMusics(artist.name)">
+            <a href="#" class="recommend_artist_item" v-for="artist in recommend_artists" :key="artist.id" @click.prevent="searchMusics(artist.name)">
                 <div class="artist_content_wrap">
                     <img :src="artist.image.url" alt="">
                     <div>{{ artist.name }}</div>
                 </div>
                 <!-- /.artist_content_wrap -->
-            </nuxt-link>
+            </a>
             <!-- /.recommend_artist_item -->
         </div>
         <div v-else style="height: 50%">

--- a/nuxt/src/pages/index.vue
+++ b/nuxt/src/pages/index.vue
@@ -11,12 +11,12 @@
     />
     <div class="container" v-else>
       <Top 
-        v-if="target_artist_name == ''"
+        v-if="!$route.query.target_artist"
         @searchMusics='searchMusics'
       />
       <MusicField v-else 
-        :music-infos="target_musics" 
-        :artist-name="target_artist_name"
+        :music-infos="$store.getters['musics/getMusics']" 
+        :artist-name="$store.getters['musics/getArtistName']"
         @searchMusics='searchMusics'
       />
     </div>
@@ -49,9 +49,14 @@ export default Vue.extend({
             is_loading: false,
         };
     },
+    fetch(){
+      if (this.$route.query.target_artist && !this.$store.getters['musics/getArtistName']){
+        this.searchMusics(this.$route.query.target_artist as string)
+      }
+    },
     mounted() {
         this.$store.commit("modal/closeModal");
-    },
+    },  
     methods: {
         async searchMusics(value: string) {
             this.$store.commit("loading/loading_state", true);
@@ -68,12 +73,14 @@ export default Vue.extend({
             else {
                 this.error_msg = "";
                 if(this.target_artist_name !== response.data[0]["artist_name"]) {
-                  this.target_musics = response.data;
-                  this.target_artist_name = this.target_musics[0]["artist_name"];
+                  this.$store.commit("musics/setMusics",response.data)
+                  this.target_artist_name = response.data[0]["artist_name"]
+                  this.$store.commit("musics/setArtistName",response.data[0]["artist_name"])
                 }
             }
             this.$store.commit("recommend/setShowRecommend", false)
             this.$store.commit("loading/loading_state", false);
+            this.$router.push({ path: '/',query:{target_artist : this.target_artist_name} })
         },
     },
     components: { Modal }

--- a/nuxt/src/store/musics.ts
+++ b/nuxt/src/store/musics.ts
@@ -1,0 +1,32 @@
+import { Music } from "~/pages/index.vue";
+
+const state = {
+    musics: [] as Array<Music>,
+    artist_name: ""
+};
+
+const mutations = {
+    setMusics(state: any, musics: Array<Music>) {
+        state.musics = musics;
+    },
+    setArtistName(state:any,artist_name:string){
+        state.artist_name = artist_name
+    }
+}
+
+const getters = {
+    getMusics(state:any){
+        return state.musics
+    },
+    getArtistName(state:any){
+        return state.artist_name
+    }
+}
+
+const musics = {
+    state: state,
+    mutations: mutations,
+    getters: getters
+};
+
+export default musics;


### PR DESCRIPTION
- stateに楽曲情報を保存して、プラウザバックで前の検索結果を参照できるようにした
- グラフ画面でリロードした時に、stateの情報が消えるので、クエリパラメータのアーティスト名から再検索して表示するようにした
- ヘッダーの検索バーをトップページでは表示しないようにした
- グラフ画面と、トップ画面でページを分けてやろうと思ったんですが、ちょっと大変そうだったのでクエリパラメータでやるやつにしました